### PR TITLE
Report validation loss

### DIFF
--- a/src/dataset/io.h
+++ b/src/dataset/io.h
@@ -3,6 +3,7 @@
 #include "dataset.h"
 
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 
 namespace dataset {
@@ -118,6 +119,45 @@ bool is_readable(const std::string& file) {
     fclose(f);
 
     return expected_size == size;
+}
+
+/**
+ * @brief Counts total positions across all datasets from provided file paths.
+ *
+ * Iterates through file paths, reads headers, and sums positions for total count.
+ *
+ * @param files Vector of dataset file paths.
+ * @return Total positions across all datasets.
+ */
+uint64_t count_total_positions(const std::vector<std::string>& files) {
+    uint64_t total_positions = 0;
+
+    // Iterate through each file path and read dataset headers to count positions
+    for (const auto& path : files) {
+        std::ifstream fin(path, std::ios::binary);
+        DataSetHeader h {};
+        fin.read(reinterpret_cast<char*>(&h), sizeof(DataSetHeader));
+        total_positions += h.entry_count;
+    }
+
+    return total_positions;
+}
+
+/**
+ * @brief Retrieves dataset file paths from the specified directory.
+ *
+ * Iterates through the directory and collects paths of dataset files.
+ *
+ * @param directory The directory containing dataset files.
+ * @return Vector of dataset file paths.
+ */
+auto fetch_dataset_paths(const std::string& directory) {
+    std::vector<std::string> files;
+    for (const auto& entry : std::filesystem::directory_iterator(directory)) {
+        const std::string path = entry.path().string();
+        files.push_back(path);
+    }
+    return files;
 }
 
 }    // namespace dataset

--- a/src/main.cu
+++ b/src/main.cu
@@ -6,17 +6,21 @@
 
 using namespace nn;
 using namespace data;
-namespace fs = std::filesystem;
 
 int main(int argc, char* argv[]) {
     argparse::ArgumentParser program("Grapheus");
 
     program.add_argument("data").required().help("Directory containing training files");
+    program.add_argument("--val-data").required().help("Directory containing validation files");
     program.add_argument("--output").required().help("Output directory for network files");
     program.add_argument("--resume").help("Weights file to resume from");
     program.add_argument("--epochs")
         .default_value(1000)
         .help("Total number of epochs to train for")
+        .scan<'i', int>();
+    program.add_argument("--epoch-size")
+        .default_value(100000000)
+        .help("Total positions in each epoch")
         .scan<'i', int>();
     program.add_argument("--save-rate")
         .default_value(50)
@@ -59,28 +63,43 @@ int main(int argc, char* argv[]) {
 
     init();
 
-    std::vector<std::string> files {};
+    // Fetch training dataset paths
+    std::vector<std::string> train_files = dataset::fetch_dataset_paths(program.get("data"));
 
-    for (const auto& entry : fs::directory_iterator(program.get("data"))) {
-        const std::string path = entry.path().string();
-        files.push_back(path);
+    // Fetch validation dataset paths
+    std::vector<std::string> val_files = dataset::fetch_dataset_paths(program.get("--val-data"));
+
+    // Print training dataset file list if files are found
+    if (!train_files.empty()) {
+        std::cout << "Training Dataset Files:" << std::endl;
+        for (const auto& file : train_files) {
+            std::cout << file << std::endl;
+        }
+        std::cout << "Total training files: " << train_files.size() << std::endl;
+        std::cout << "Total training positions: " << dataset::count_total_positions(train_files)
+                  << std::endl
+                  << std::endl;
+    } else {
+        std::cout << "No training files found in " << program.get("data") << std::endl << std::endl;
+        exit(0);
     }
 
-    uint64_t total_positions = 0;
-    for (const auto& file_path : files) {
-        FILE*                  fin = fopen(file_path.c_str(), "rb");
-
-        dataset::DataSetHeader h {};
-        fread(&h, sizeof(dataset::DataSetHeader), 1, fin);
-
-        total_positions += h.entry_count;
-        fclose(fin);
+    // Print validation dataset file list if files are found
+    if (!val_files.empty()) {
+        std::cout << "Validation Dataset Files:" << std::endl;
+        for (const auto& file : val_files) {
+            std::cout << file << std::endl;
+        }
+        std::cout << "Total validation files: " << val_files.size() << std::endl;
+        std::cout << "Total validation positions: " << dataset::count_total_positions(val_files)
+                  << std::endl;
+    } else {
+        std::cout << "No validation files found in " << program.get("--val-data") << std::endl;
+        exit(0);
     }
-
-    std::cout << "Loading a total of " << files.size() << " files with " << total_positions
-              << " total position(s)" << std::endl;
 
     const int   total_epochs  = program.get<int>("--epochs");
+    const int   epoch_size    = program.get<int>("--epoch-size");
     const int   save_rate     = program.get<int>("--save-rate");
     const int   ft_size       = program.get<int>("--ft-size");
     const float lambda        = program.get<float>("--lambda");
@@ -90,6 +109,7 @@ int main(int argc, char* argv[]) {
     const float lr_drop_ratio = program.get<float>("--lr-drop-ratio");
 
     std::cout << "Epochs: " << total_epochs << "\n"
+              << "Epochs Size: " << epoch_size << "\n"
               << "Save Rate: " << save_rate << "\n"
               << "FT Size: " << ft_size << "\n"
               << "Lambda: " << lambda << "\n"
@@ -98,8 +118,14 @@ int main(int argc, char* argv[]) {
               << "LR Drop @ " << lr_drop_epoch << "\n"
               << "LR Drop R " << lr_drop_ratio << std::endl;
 
-    dataset::BatchLoader<chess::Position> loader {files, batch_size};
-    loader.start();
+    using BatchLoader = dataset::BatchLoader<chess::Position>;
+
+    BatchLoader train_loader {train_files, batch_size};
+    BatchLoader val_loader {val_files, batch_size};
+
+    auto*       ds = train_loader.next();
+
+    std::cout << ds->positions.size() << std::endl;
 
     model::BerserkModel model {static_cast<size_t>(ft_size), lambda, static_cast<size_t>(save_rate)};
     model.set_loss(MPE {2.5, true});
@@ -117,9 +143,10 @@ int main(int argc, char* argv[]) {
         std::cout << "Loaded weights from previous " << *previous << std::endl;
     }
 
-    model.train(loader, total_epochs);
+    model.train(train_loader, val_loader, total_epochs, epoch_size);
 
-    loader.kill();
+    train_loader.kill();
+    val_loader.kill();
 
     close();
     return 0;

--- a/src/main.cu
+++ b/src/main.cu
@@ -126,10 +126,6 @@ int main(int argc, char* argv[]) {
     train_loader.start();
     val_loader.start();
 
-    auto* ds = train_loader.next();
-
-    std::cout << ds->positions.size() << std::endl;
-
     model::BerserkModel model {static_cast<size_t>(ft_size), lambda, static_cast<size_t>(save_rate)};
     model.set_loss(MPE {2.5, true});
     model.set_lr_schedule(StepDecayLRSchedule {lr, lr_drop_ratio, lr_drop_epoch});

--- a/src/main.cu
+++ b/src/main.cu
@@ -123,7 +123,10 @@ int main(int argc, char* argv[]) {
     BatchLoader train_loader {train_files, batch_size};
     BatchLoader val_loader {val_files, batch_size};
 
-    auto*       ds = train_loader.next();
+    train_loader.start();
+    val_loader.start();
+
+    auto* ds = train_loader.next();
 
     std::cout << ds->positions.size() << std::endl;
 

--- a/src/models/berserk.h
+++ b/src/models/berserk.h
@@ -106,7 +106,7 @@ struct BerserkModel : ChessModel {
 
         auto& target = m_loss->target;
 
-#pragma omp parallel for schedule(static) num_threads(16)
+#pragma omp parallel for schedule(static) num_threads(6)
         for (int b = 0; b < positions->header.entry_count; b++) {
             chess::Position* pos = &positions->positions[b];
             // fill in the inputs and target values

--- a/src/models/chessmodel.h
+++ b/src/models/chessmodel.h
@@ -56,9 +56,7 @@ struct ChessModel : Model {
 
         this->compile(train_loader.batch_size);
 
-        const int val_epoch_size = epoch_size / 10;
-
-        Timer     t {};
+        Timer t {};
         for (int i = 1; i <= epochs; i++) {
             t.start();
 
@@ -93,7 +91,7 @@ struct ChessModel : Model {
             }
 
             // Validation phase
-            for (int b = 1; b <= val_epoch_size / val_loader.batch_size; b++) {
+            for (int b = 1; b <= epoch_size / val_loader.batch_size; b++) {
                 auto* ds = val_loader.next();
                 setup_inputs_and_outputs(ds);
 

--- a/src/models/chessmodel.h
+++ b/src/models/chessmodel.h
@@ -38,14 +38,28 @@ struct ChessModel : Model {
      */
     virtual void setup_inputs_and_outputs(dataset::DataSet<chess::Position>* positions) = 0;
 
-    /// @brief Train the model with the given batch loader.
-    /// @param loader Batch loader for dataset input.
-    /// @param epochs Number of training epochs.
-    /// @param epoch_size Size of each training epoch.
-    void train(dataset::BatchLoader<chess::Position>& loader,
-               int                                    epochs     = 1500,
-               int                                    epoch_size = 1e8) {
-        this->compile(loader.batch_size);
+    using BatchLoader = dataset::BatchLoader<chess::Position>;
+
+    /**
+     * @brief Trains the model using the provided train and validation loaders for a specified number
+     * of epochs.
+     *
+     * @param train_loader The batch loader for training data.
+     * @param val_loader The batch loader for validation data.
+     * @param epochs Number of training epochs (default: 1500).
+     * @param epoch_size Number of batches per epoch (default: 1e8).
+     */
+    void train(BatchLoader& train_loader,
+               BatchLoader& val_loader,
+               int          epochs     = 1500,
+               int          epoch_size = 1e8) {
+
+        this->compile(train_loader.batch_size);
+
+        int val_epoch_size = epoch_size / 10;
+
+        std::cout << "Starting training: " << std::endl;
+        std::cout << epoch_size << std::endl;
 
         Timer t {};
         for (int i = 1; i <= epochs; i++) {
@@ -53,9 +67,11 @@ struct ChessModel : Model {
 
             uint64_t prev_print_tm    = 0;
             float    total_epoch_loss = 0;
+            float    total_val_loss   = 0;
 
-            for (int b = 1; b <= epoch_size / loader.batch_size; b++) {
-                auto* ds = loader.next();
+            // Training phase
+            for (int b = 1; b <= epoch_size / train_loader.batch_size; b++) {
+                auto* ds = train_loader.next();
                 setup_inputs_and_outputs(ds);
 
                 float batch_loss = batch();
@@ -64,7 +80,7 @@ struct ChessModel : Model {
 
                 t.stop();
                 uint64_t elapsed = t.elapsed();
-                if (elapsed - prev_print_tm > 1000 || b == epoch_size / loader.batch_size) {
+                if (elapsed - prev_print_tm > 1000 || b == epoch_size / train_loader.batch_size) {
                     prev_print_tm = elapsed;
 
                     printf("\rep = [%4d], epoch_loss = [%1.8f], batch = [%5d], batch_loss = [%1.8f], "
@@ -79,10 +95,25 @@ struct ChessModel : Model {
                 }
             }
 
+            // Validation phase
+            // for (int b = 1; b <= val_epoch_size / val_loader.batch_size; b++) {
+            //     auto* ds = val_loader.next();
+            //     setup_inputs_and_outputs(ds);
+
+            //     float val_batch_loss = loss();
+            //     total_val_loss += val_batch_loss;
+
+            //     float val_loss = total_val_loss / b;
+
+            //     printf(", val_loss = [%1.8]", val_loss);
+            // }
+
             std::cout << std::endl;
 
-            float epoch_loss = total_epoch_loss / (epoch_size / loader.batch_size);
-            next_epoch(epoch_loss, 0.0);
+            float epoch_loss = total_epoch_loss / (epoch_size / train_loader.batch_size);
+            float val_loss   = total_val_loss / (epoch_size / val_loader.batch_size);
+
+            next_epoch(epoch_loss, val_loss);
         }
     }
 
@@ -236,4 +267,4 @@ struct ChessModel : Model {
         }
     }
 };
-}
+}    // namespace model

--- a/src/models/chessmodel.h
+++ b/src/models/chessmodel.h
@@ -56,12 +56,9 @@ struct ChessModel : Model {
 
         this->compile(train_loader.batch_size);
 
-        int val_epoch_size = epoch_size / 10;
+        const int val_epoch_size = epoch_size / 10;
 
-        std::cout << "Starting training: " << std::endl;
-        std::cout << epoch_size << std::endl;
-
-        Timer t {};
+        Timer     t {};
         for (int i = 1; i <= epochs; i++) {
             t.start();
 
@@ -96,24 +93,20 @@ struct ChessModel : Model {
             }
 
             // Validation phase
-            // for (int b = 1; b <= val_epoch_size / val_loader.batch_size; b++) {
-            //     auto* ds = val_loader.next();
-            //     setup_inputs_and_outputs(ds);
+            for (int b = 1; b <= val_epoch_size / val_loader.batch_size; b++) {
+                auto* ds = val_loader.next();
+                setup_inputs_and_outputs(ds);
 
-            //     float val_batch_loss = loss();
-            //     total_val_loss += val_batch_loss;
-
-            //     float val_loss = total_val_loss / b;
-
-            //     printf(", val_loss = [%1.8]", val_loss);
-            // }
-
-            std::cout << std::endl;
+                float val_batch_loss = loss();
+                total_val_loss += val_batch_loss;
+            }
 
             float epoch_loss = total_epoch_loss / (epoch_size / train_loader.batch_size);
             float val_loss   = total_val_loss / (epoch_size / val_loader.batch_size);
 
+            printf(", val_loss = [%1.8f]", val_loss);
             next_epoch(epoch_loss, val_loss);
+            std::cout << std::endl;
         }
     }
 


### PR DESCRIPTION
There's need to check validation loss to know if the net is generalizing well. So I added validation loss reporting

* Add `--val-data` as the launch argument for passing the validation datasets paths 
* Print validation loss after each epoch
* Write the validation to the loss.csv file
* Add two helper functions in `dataset`: `dataset::fetch_dataset_paths` for retrieving all files found in directory and `dataset::count_total_positions` for counting total number of positions given a list of files
* Add `--epoch-size` as a launch arguments