### PR TITLE
Berserk Model Update + General Fixes

### DIFF
--- a/src/main.cu
+++ b/src/main.cu
@@ -156,7 +156,8 @@ int main(int argc, char* argv[]) {
     model.train(train_loader, val_loader, total_epochs, epoch_size, val_epoch_size);
 
     train_loader.kill();
-    val_loader->kill();
+    if (val_loader.has_value())
+        val_loader->kill();
 
     close();
     return 0;

--- a/src/main.cu
+++ b/src/main.cu
@@ -75,7 +75,7 @@ int main(int argc, char* argv[]) {
     if (!train_files.empty()) {
         std::cout << "Training Dataset Files:" << std::endl;
         for (const auto& file : train_files) {
-            std::cout << file << std::endl;
+            std::cout << "\t" << file << std::endl;
         }
         std::cout << "Total training files: " << train_files.size() << std::endl;
         std::cout << "Total training positions: " << dataset::count_total_positions(train_files)
@@ -97,7 +97,7 @@ int main(int argc, char* argv[]) {
     if (!val_files.empty()) {
         std::cout << "Validation Dataset Files:" << std::endl;
         for (const auto& file : val_files) {
-            std::cout << file << std::endl;
+            std::cout << "\t" << file << std::endl;
         }
         std::cout << "Total validation files: " << val_files.size() << std::endl;
         std::cout << "Total validation positions: " << dataset::count_total_positions(val_files)

--- a/src/models/berserk.h
+++ b/src/models/berserk.h
@@ -12,6 +12,7 @@ struct BerserkModel : ChessModel {
     const float  sigmoid_scale = 1.0 / 160.0;
     const float  quant_one     = 32.0;
     const float  quant_two     = 32.0;
+    const float  quant_three   = 32.0;
 
     const size_t n_features    = 16 * 12 * 64;
     const size_t n_l1          = 16;
@@ -60,10 +61,10 @@ struct BerserkModel : ChessModel {
             QuantizerEntry<int16_t>(&ft->bias.values, quant_one),
             QuantizerEntry<int8_t>(&l1->weights.values, quant_two),
             QuantizerEntry<int32_t>(&l1->bias.values, quant_two),
-            QuantizerEntry<float>(&l2->weights.values, 1.0),
-            QuantizerEntry<float>(&l2->bias.values, quant_two),
-            QuantizerEntry<float>(&pos_eval->weights.values, 1.0),
-            QuantizerEntry<float>(&pos_eval->bias.values, quant_two),
+            QuantizerEntry<int16_t>(&l2->weights.values, quant_three),
+            QuantizerEntry<int32_t>(&l2->bias.values, quant_three),
+            QuantizerEntry<int16_t>(&pos_eval->weights.values, quant_three),
+            QuantizerEntry<int32_t>(&pos_eval->bias.values, quant_three),
         });
     }
 
@@ -106,7 +107,7 @@ struct BerserkModel : ChessModel {
 
         auto& target = m_loss->target;
 
-#pragma omp parallel for schedule(static) num_threads(6)
+#pragma omp parallel for schedule(static) num_threads(4)
         for (int b = 0; b < positions->header.entry_count; b++) {
             chess::Position* pos = &positions->positions[b];
             // fill in the inputs and target values
@@ -156,4 +157,4 @@ struct BerserkModel : ChessModel {
     }
 };
 
-}
+}    // namespace model

--- a/src/models/chessmodel.h
+++ b/src/models/chessmodel.h
@@ -104,7 +104,7 @@ struct ChessModel : Model {
                 }
             }
 
-            float epoch_loss = total_epoch_loss / (val_epoch_size / train_loader.batch_size);
+            float epoch_loss = total_epoch_loss / (epoch_size / train_loader.batch_size);
             float val_loss   = (val_loader.has_value())
                                    ? total_val_loss / (val_epoch_size / val_loader->batch_size)
                                    : 0;

--- a/src/models/chessmodel.h
+++ b/src/models/chessmodel.h
@@ -228,7 +228,7 @@ struct ChessModel : Model {
             std::cout << "\n";
             float min = 10000000;
             float max = -10000000;
-            for (int m = 0; m < min_values[i].m; m++) {
+            for (int m = 0; m < min_values[i].size(); m++) {
                 min = std::min(min, min_values[i](m));
                 max = std::max(max, max_values[i](m));
             }

--- a/src/models/chessmodel.h
+++ b/src/models/chessmodel.h
@@ -228,7 +228,7 @@ struct ChessModel : Model {
             std::cout << "\n";
             float min = 10000000;
             float max = -10000000;
-            for (int m = 0; m < min_values.size(); m++) {
+            for (int m = 0; m < min_values[i].m; m++) {
                 min = std::min(min, min_values[i](m));
                 max = std::max(max, max_values[i](m));
             }


### PR DESCRIPTION
Update the Berserk model to quantize all layers.

Additional fixes:
- `distribution` using the wrong `size()`
- Segfault due to killing a validation loader even with no validation loader
- File list printing improved with a tab indent
- Epoch loss calculated based on validation epoch size